### PR TITLE
Fixing travis build in 0.0.x

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
 language: node_js
 node_js:
   - 1.8.7
+script: "make"

--- a/lib/init.js
+++ b/lib/init.js
@@ -335,11 +335,11 @@ var AppRouter = Backbone.Router.extend({
   }
 });
 
-var app_router = new AppRouter;
+var app_router = new AppRouter();
 
 app_router.on('route:defaultRoute', function(actions) {
     alert(actions);
-})
+});
 
 Backbone.history.start();
 


### PR DESCRIPTION
Fixing travis build to run make instead npm and add missing parentheses to lib/init.js
